### PR TITLE
Added support for metadata device for internal KVDB

### DIFF
--- a/community/portworx/templates/portworx-ds.yaml
+++ b/community/portworx/templates/portworx-ds.yaml
@@ -111,18 +111,18 @@ spec:
               {{- if ne $journalDevice "none" }}
               "-j", "{{ $journalDevice }}",
               {{- end -}}
-
-              {{- if empty $etcdEndPoints }}
-              "-b",
-              {{- else }}
+  
               {{- if eq $internalKVDB true }}
-              "-b",
+                "-b",
+              {{ end -}}
+              
+              {{- if empty $etcdEndPoints }}
+                {{- if eq $internalKVDB false }}
+                  {{ required "A valid ETCD url in the format etcd:http://<your-etcd-endpoint> is required. Verify that the key is correct and there isnt any typo in specifying that, also ensure it is accessible from all node of your kubernetes cluster" $etcdEndPoints }}
+                {{- end -}}
               {{- else -}}
-              "-k", "{{ regexReplaceAllLiteral "(;)" .kvdb "," }}",
+                "-k", "{{ regexReplaceAllLiteral "(;)" .kvdb "," }}",
               {{ end -}}
-              {{ end -}}
-
-
 
               "-c", "{{ required "Clustername cannot be empty" .clusterName }}",
 
@@ -168,7 +168,8 @@ spec:
                 {{- end }}
               {{ end -}}
 
-              "-x", "kubernetes"
+              "-x", "kubernetes",
+              "-metadata", "{{ printf "size=%d" (int64 .storage.metadataSize) }}"
              ]
            {{- end }}
           env:

--- a/community/portworx/templates/portworx-ds.yaml
+++ b/community/portworx/templates/portworx-ds.yaml
@@ -12,9 +12,7 @@
 {{- $managementInterface := .Values.network.managementInterface | default "none" }}
 
 {{- $envVars := .Values.envVars | default "none" }}
-{{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
 
-{{- $pksInstall := .Values.pksInstall | default false }}
 {{- $internalKVDB := .Values.internalKVDB | default false }}
 {{- $csi := .Values.csi | default false }}
 
@@ -196,11 +194,6 @@ spec:
                   name: "{{ $registrySecret }}"
             {{- end }}
 
-            {{- if eq $pksInstall true }}
-            - name: "PRE-EXEC"
-              value: "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
-            {{- end }}
-
             {{- if eq $csi true }}
             - name: CSI_ENDPOINT
               value: unix:///var/lib/kubelet/plugins/com.openstorage.pxd/csi.sock
@@ -289,14 +282,8 @@ spec:
           {{- end }}
 
           {{- end }}
-
-          {{- if eq $isCoreOS true}}
-            - name: src
-              mountPath: /lib/modules
-          {{- else }}
             - name: src
               mountPath: /usr/src
-          {{- end }}
           {{- end }}
 
           {{- if eq $csi true }}
@@ -339,10 +326,10 @@ spec:
           {{- end}}
         - name: dockersock
           hostPath:
-            path: {{if eq $pksInstall true}}/var/vcap/sys/run/docker/docker.sock{{else}}/var/run/docker.sock{{end}}
+            path: /var/run/docker.sock
         - name: containerdsock
           hostPath:
-            path: {{if eq $pksInstall true}}/var/vcap/sys/run/containerd{{else}}/run/containerd{{end}}
+            path: /run/containerd
           {{- if eq $csi true}}
         - name: csi-driver-path
           hostPath:
@@ -354,11 +341,11 @@ spec:
             path: /etc/pwx
         - name: cores
           hostPath:
-            path: {{if eq $pksInstall true }}/var/vcap/store/cores{{else}}/var/cores{{end}}
+            path: /var/cores
         {{- if eq (.Values.deploymentType | upper | lower) "oci" }}
         - name: optpwx
           hostPath:
-            path: {{if eq $pksInstall true }}/var/vcap/store/opt/pwx{{else}}/opt/pwx{{end}}
+            path: /opt/pwx
         - name: sysdmount
           hostPath:
             path: /etc/systemd/system
@@ -393,16 +380,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet
         {{- end }}
-        {{- if eq $isCoreOS true}}
-        - name: src
-          hostPath:
-            path: /lib/modules
-        {{- else }}
-        - name: src
+         - name: src
           hostPath:
             path: /usr/src
-        {{- end }}
-        - name: dockerplugins
+         - name: dockerplugins
           hostPath:
             path: /run/docker/plugins
         - name: hostproc

--- a/community/portworx/values-metadata.yaml
+++ b/community/portworx/values-metadata.yaml
@@ -68,6 +68,17 @@ storage:
       type: "string"
       immutable: false
       required: false
+  
+  metadataSize:
+    __metadata:
+      name: "metadataSize"
+      label: "metadata Disk Size"
+      description: "Specify the size of a separate block device to be used as a metadata device for px metadata. Adding a metadata disk will enable better performance"
+      type: "int64"
+      immutable: false
+      required: false
+
+
 
 
 network:

--- a/community/portworx/values.yaml
+++ b/community/portworx/values.yaml
@@ -10,7 +10,8 @@ storage:
   usefileSystemDrive: false             # true/false Instructs PX to use an unmounted Drive even if it has a filesystem.
   usedrivesAndPartitions: false         # Defaults to false. Change to true and PX will use unmounted drives and partitions.
   drives: none                          # NOTE: This is a ";" seperated list of drives. For eg: "/dev/sda;/dev/sdb;/dev/sdc" Defaults to use -A switch.
-  journalDevice:
+  journalDevice: none
+  metadataSize: 64
 
 network:
   dataInterface: none                   # Name of the interface <ethX>
@@ -22,16 +23,21 @@ envVars: none                         # NOTE: This is a ";" seperated list of en
 stork: true                           # Use Stork https://docs.portworx.com/scheduler/kubernetes/stork.html for hyperconvergence.
 storkVersion: 2.1.0
 
-customRegistryURL:
-registrySecret:
+customRegistryURL: 
+registrySecret: 
 
 lighthouse: true
 lighthouseVersion: 2.0.4
 lighthouseSyncVersion: 0.4
 lighthouseStorkConnectorVersion: 0.2
 
-
 csi: false                            # Enable CSI
+
+isTargetOSCoreOS:                 # set this to true if running on coreOS
+pksInstall: 
+misc: ""
+openshiftInstall: 
+deployOnMaster: 
 
 internalKVDB: false                   # internal KVDB
 

--- a/community/portworx/values.yaml
+++ b/community/portworx/values.yaml
@@ -33,12 +33,6 @@ lighthouseStorkConnectorVersion: 0.2
 
 csi: false                            # Enable CSI
 
-isTargetOSCoreOS:                 # set this to true if running on coreOS
-pksInstall: 
-misc: ""
-openshiftInstall: 
-deployOnMaster: 
-
 internalKVDB: false                   # internal KVDB
 
 etcd:


### PR DESCRIPTION
1. Default size for the metadata device is 64GB
2. Will be set by default

Signed-off-by: Tapas Sharma <tapas@portworx.com>
```
 helm lint  --set internalKVDB=true,journalDevice=auto,metadataSize=64 --values values.yaml                                                 
==> Linting .
Lint OK

1 chart(s) linted, no failures
```