### PR TITLE
Addressed review comments

### DIFF
--- a/community/portworx/templates/portworx-ds.yaml
+++ b/community/portworx/templates/portworx-ds.yaml
@@ -172,7 +172,7 @@ spec:
               "-x", "kubernetes",
               {{- if ne $metadataSize 0 }}
               "-metadata" "{{ printf "size=%d" (int64 $metadataSize) }}",
-              {{- end -}}
+              {{- end }}
              ]
            {{- end }}
           env:

--- a/community/portworx/templates/portworx-storageclasses.yaml
+++ b/community/portworx/templates/portworx-storageclasses.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: portworx-db-sc
   labels:
@@ -15,7 +15,7 @@ parameters:
   io_profile: "db"
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: portworx-db2-sc
   labels:
@@ -32,7 +32,7 @@ parameters:
    io_profile: "db"
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: portworx-shared-sc
   labels:
@@ -54,7 +54,7 @@ parameters:
 # Please refer to : https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html
 #
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: portworx-null-sc
   labels:

--- a/community/portworx/values.yaml
+++ b/community/portworx/values.yaml
@@ -10,7 +10,7 @@ storage:
   usedrivesAndPartitions: false         # Defaults to false. Change to true and PX will use unmounted drives and partitions.
   drives: none                          # NOTE: This is a ";" seperated list of drives. For eg: "/dev/sda;/dev/sdb;/dev/sdc" Defaults to use -A switch.
   journalDevice: none
-  metadataSize: none
+  metadataSize: 0
 
 network:
   dataInterface: none                   # Name of the interface <ethX>


### PR DESCRIPTION
1. Moved storage.kbs.io/v1beta1 to storage.k8s.io/v1
2. Changed the default value of metadataSize from none to 0

Signed-off-by: Tapas Sharma <tapas@portworx.com>